### PR TITLE
feat: wire up Animal Safari Match (route, game list, Supabase, migrat…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -48,7 +48,7 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "16kB",
+                  "maximumWarning": "20kB",
                   "maximumError": "50kB"
                 },
                 {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -43,6 +43,11 @@ export const routes: Routes = [
       import('./pages/perfect-harvest-game/perfect-harvest-game.component').then(m => m.PerfectHarvestGameComponent),
   },
   {
+    path: 'animal-safari-match',
+    loadComponent: () =>
+      import('./pages/animal-safari-match/animal-safari-match.component').then(m => m.AnimalSafariMatchComponent),
+  },
+  {
     path: 'event/chloe-1st-birthday',
     loadComponent: () =>
       import('./pages/chloe-birthday/chloe-birthday.component').then(m => m.ChloeBirthdayComponent),

--- a/src/app/services/supabase.service.ts
+++ b/src/app/services/supabase.service.ts
@@ -186,4 +186,93 @@ export class SupabaseService {
     }
     return data && data.length > 0 ? data[0] : null;
   }
+
+  // Animal Safari Match Methods
+  // ---------------------------------------------------------------------------
+  // The game's player-owned progression lives in localStorage (frontend-only
+  // mechanic). Supabase only stores anonymous, append-only events: a row per
+  // finished level + a row per animal discovered, which feed the community
+  // "Players have discovered N lions" counter. See
+  //   supabase/migrations/20260619120000_create_animal_safari_match.sql
+
+  // Log one completed level (anonymous play session).
+  async insertSafariSession(session: {
+    playerName: string;
+    theme: string;
+    pairs: number;
+    moves: number;
+    durationSeconds: number;
+    animalsFound: number;
+    coinsEarned: number;
+  }) {
+    const { data, error } = await this.supabase
+      .from('safari_sessions')
+      .insert([
+        {
+          player_name: session.playerName,
+          theme: session.theme,
+          pairs: session.pairs,
+          moves: session.moves,
+          duration_seconds: session.durationSeconds,
+          animals_found: session.animalsFound,
+          coins_earned: session.coinsEarned,
+          created_at: new Date().toISOString(),
+        },
+      ]);
+
+    if (error) {
+      console.error('Insert safari session error:', error);
+      throw error;
+    }
+    return data;
+  }
+
+  // Append one discovery event per animal matched in a run (batched).
+  async recordSafariDiscoveries(
+    playerName: string,
+    discoveries: { animalId: string; rarity: string; isFirst: boolean }[],
+  ) {
+    if (!discoveries.length) return null;
+    const rows = discoveries.map(d => ({
+      player_name: playerName,
+      animal_id: d.animalId,
+      rarity: d.rarity,
+      is_first: d.isFirst,
+      created_at: new Date().toISOString(),
+    }));
+
+    const { data, error } = await this.supabase.from('safari_discoveries').insert(rows);
+
+    if (error) {
+      console.error('Insert safari discoveries error:', error);
+      throw error;
+    }
+    return data;
+  }
+
+  // Read per-animal community tallies (drives the discovery counter).
+  async getSafariCommunityTotals() {
+    const { data, error } = await this.supabase
+      .from('safari_community_totals')
+      .select('*');
+
+    if (error) {
+      console.error('Fetch safari community totals error:', error);
+      throw error;
+    }
+    return data as { animal_id: string; total_found: number; total_discoverers: number }[] | null;
+  }
+
+  // Total number of anonymous sessions logged (community "games played").
+  async getSafariSessionCount() {
+    const { count, error } = await this.supabase
+      .from('safari_sessions')
+      .select('*', { count: 'exact', head: true });
+
+    if (error) {
+      console.error('Fetch safari session count error:', error);
+      throw error;
+    }
+    return count ?? 0;
+  }
 }

--- a/src/app/types/game.types.ts
+++ b/src/app/types/game.types.ts
@@ -44,13 +44,12 @@ export const GAMES: GameItem[] = [
     route: '/perfect-harvest-game'
   },
   {
-    id: 'memory-match',
-    title: 'Memory Match',
-    description: 'Test your memory with this classic card matching game. Multiple difficulty levels.',
+    id: 'animal-safari-match',
+    title: 'Animal Safari Match',
+    description: 'A gentle 3D memory game for little explorers. Open safari tents, match the animals, collect a parade you keep forever, and open Safari Eggs.',
     tags: ['single-player', 'strategy'],
-    imageUrl: 'https://via.placeholder.com/640x360?text=Memory+Match',
-    route: '/memory-match',
-    isComingSoon: true
+    imageUrl: '/assets/images/game-covers/animal-safari-cover.png',
+    route: '/animal-safari-match'
   },
   {
     id: 'snake-game',

--- a/supabase/migrations/20260619000000_create_perfect_harvest_scores.sql
+++ b/supabase/migrations/20260619000000_create_perfect_harvest_scores.sql
@@ -1,0 +1,61 @@
+-- ============================================================================
+-- Perfect Harvest — leaderboard table
+-- ============================================================================
+-- Run this in the Supabase dashboard: SQL Editor → New query → paste → Run.
+-- Project: hqnfpjdkdiauzqolrwzn  (matches src/app/services/supabase.service.ts)
+--
+-- The Angular app talks to Supabase directly with the public "anon" key, so
+-- Row Level Security (RLS) is enabled with policies that allow anyone to read
+-- the board and submit a score (same model as the other game tables).
+-- ============================================================================
+
+-- 1) Table -------------------------------------------------------------------
+create table if not exists public.perfect_harvest_scores (
+  id            uuid        primary key default gen_random_uuid(),
+  player_name   text        not null,
+  score         integer     not null default 0,
+  perfect_count integer     not null default 0,
+  highest_combo integer     not null default 0,
+  created_at    timestamptz not null default now(),
+
+  -- light sanity guards (not anti-cheat — just keeps the board clean)
+  constraint perfect_harvest_name_len   check (char_length(player_name) between 1 and 40),
+  constraint perfect_harvest_score_rng  check (score >= 0 and score <= 5000000),
+  constraint perfect_harvest_perfect_ok check (perfect_count >= 0),
+  constraint perfect_harvest_combo_ok   check (highest_combo >= 0)
+);
+
+comment on table public.perfect_harvest_scores is 'High scores for the Perfect Harvest browser game.';
+
+-- 2) Indexes -----------------------------------------------------------------
+-- Global Top-N leaderboard query: order by score desc.
+create index if not exists perfect_harvest_score_idx
+  on public.perfect_harvest_scores (score desc);
+
+-- Personal-best lookups: where player_name = ? order by score desc.
+create index if not exists perfect_harvest_player_idx
+  on public.perfect_harvest_scores (player_name, score desc);
+
+-- 3) Row Level Security ------------------------------------------------------
+alter table public.perfect_harvest_scores enable row level security;
+
+-- Anyone (anon + authenticated) can read the leaderboard.
+drop policy if exists "Perfect Harvest scores are public" on public.perfect_harvest_scores;
+create policy "Perfect Harvest scores are public"
+  on public.perfect_harvest_scores
+  for select
+  using (true);
+
+-- Anyone can submit a score (one insert per completed run, enforced client-side).
+drop policy if exists "Anyone can submit a Perfect Harvest score" on public.perfect_harvest_scores;
+create policy "Anyone can submit a Perfect Harvest score"
+  on public.perfect_harvest_scores
+  for insert
+  with check (true);
+
+-- No update / delete policies → those operations are denied for anon by default.
+
+-- ============================================================================
+-- Rollback (run only if you need to remove the table):
+--   drop table if exists public.perfect_harvest_scores cascade;
+-- ============================================================================

--- a/supabase/migrations/20260619120000_create_animal_safari_match.sql
+++ b/supabase/migrations/20260619120000_create_animal_safari_match.sql
@@ -1,0 +1,194 @@
+-- ============================================================================
+-- Animal Safari Match — game tables
+-- ============================================================================
+-- Run this in the Supabase dashboard: SQL Editor → New query → paste → Run.
+-- Project: hqnfpjdkdiauzqolrwzn  (matches src/app/services/supabase.service.ts)
+-- Safe to re-run: schema uses IF NOT EXISTS and the catalog is re-seeded in full.
+--
+-- Design note — "frontend only mechanic + database":
+--   There is NO custom backend and NO auth. The Angular app talks to Supabase
+--   directly with the public "anon" key, exactly like the other arcade games.
+--   The *player-owned* progression from the PRD (permanent collection, coins,
+--   stickers, parade, daily streak, per-device stats) lives entirely on the
+--   client in localStorage — that is the offline-first "frontend only mechanic".
+--
+--   Supabase only stores the three things that benefit from being shared/global:
+--     1) safari_animals    — the animal catalog (seeded below, read-only).
+--     2) safari_sessions   — one row per finished level (anonymous play log).
+--     3) safari_discoveries — one append-only event per animal matched, which
+--                             powers the community "Players have discovered N
+--                             lions" counter (see the safari_community_totals
+--                             view). No per-user rows, no updates → fits the
+--                             anon insert + public select RLS model cleanly.
+--
+--   The 24 animals map 1:1 to the GLB models in src/assets/models/ and to
+--   ANIMALS in src/app/pages/animal-safari-match/safari-data.ts.
+-- ============================================================================
+
+-- 1) Animal catalog ----------------------------------------------------------
+-- Read-only reference data. Seeded below; the client keeps its own copy too, so
+-- gameplay never blocks on this table.
+create table if not exists public.safari_animals (
+  id          text        primary key,                 -- stable slug, e.g. 'lion'
+  name        text        not null,
+  rarity      text        not null,                     -- common | rare | epic | legendary
+  theme       text        not null,                     -- savanna | farmyard | riverside
+  emoji       text        not null,                     -- glyph used for the fallback card
+  model       text,                                     -- GLB basename, e.g. 'animal-lion'
+  created_at  timestamptz not null default now(),
+
+  constraint safari_animals_rarity_ck check (rarity in ('common','rare','epic','legendary'))
+);
+
+comment on table public.safari_animals is 'Animal Safari Match — animal catalog (reference data).';
+
+-- 2) Play sessions -----------------------------------------------------------
+-- One row per completed level. Anonymous (player_name is a chosen display name,
+-- not an account). Used for personal stats + a global "games played" count.
+create table if not exists public.safari_sessions (
+  id               uuid        primary key default gen_random_uuid(),
+  player_name      text        not null,
+  theme            text        not null,
+  pairs            integer     not null default 0,      -- pairs on the board (4 / 6 / 8)
+  moves            integer     not null default 0,
+  duration_seconds integer     not null default 0,
+  animals_found    integer     not null default 0,
+  coins_earned     integer     not null default 0,
+  created_at       timestamptz not null default now(),
+
+  constraint safari_sessions_name_len  check (char_length(player_name) between 1 and 40),
+  constraint safari_sessions_pairs_ck  check (pairs        between 1 and 24),
+  constraint safari_sessions_moves_ck  check (moves        >= 0 and moves <= 100000),
+  constraint safari_sessions_dur_ck    check (duration_seconds >= 0 and duration_seconds <= 86400),
+  constraint safari_sessions_found_ck  check (animals_found >= 0),
+  constraint safari_sessions_coins_ck  check (coins_earned  >= 0 and coins_earned <= 1000000)
+);
+
+comment on table public.safari_sessions is 'Animal Safari Match — one anonymous row per finished level.';
+
+-- 3) Discovery events --------------------------------------------------------
+-- Append-only log: one row per animal matched in a run. `is_first` marks the
+-- player's very first lifetime discovery of that animal (decided client-side
+-- from local collection). Aggregated by the community view below.
+create table if not exists public.safari_discoveries (
+  id          uuid        primary key default gen_random_uuid(),
+  player_name text        not null,
+  animal_id   text        not null,
+  rarity      text        not null,
+  is_first    boolean     not null default false,
+  created_at  timestamptz not null default now(),
+
+  constraint safari_disc_name_len  check (char_length(player_name) between 1 and 40),
+  constraint safari_disc_rarity_ck check (rarity in ('common','rare','epic','legendary'))
+);
+
+comment on table public.safari_discoveries is 'Animal Safari Match — append-only animal discovery/match events (powers the community counter).';
+
+-- 4) Indexes -----------------------------------------------------------------
+create index if not exists safari_sessions_created_idx
+  on public.safari_sessions (created_at desc);
+
+create index if not exists safari_discoveries_animal_idx
+  on public.safari_discoveries (animal_id);
+
+-- 5) Community totals view ---------------------------------------------------
+-- "Players have discovered 12,500 lions." One read returns every animal's tally.
+-- security_invoker = on → the view respects the base table's (public) RLS.
+create or replace view public.safari_community_totals
+  with (security_invoker = on) as
+  select animal_id,
+         count(*)::bigint                              as total_found,
+         count(*) filter (where is_first)::bigint      as total_discoverers
+  from public.safari_discoveries
+  group by animal_id;
+
+comment on view public.safari_community_totals is 'Animal Safari Match — per-animal community discovery tallies.';
+
+-- 6) Row Level Security ------------------------------------------------------
+alter table public.safari_animals     enable row level security;
+alter table public.safari_sessions    enable row level security;
+alter table public.safari_discoveries enable row level security;
+
+drop policy if exists "Safari animals are public" on public.safari_animals;
+create policy "Safari animals are public"
+  on public.safari_animals for select using (true);
+
+drop policy if exists "Safari sessions are public" on public.safari_sessions;
+create policy "Safari sessions are public"
+  on public.safari_sessions for select using (true);
+
+drop policy if exists "Anyone can log a Safari session" on public.safari_sessions;
+create policy "Anyone can log a Safari session"
+  on public.safari_sessions for insert with check (true);
+
+drop policy if exists "Safari discoveries are public" on public.safari_discoveries;
+create policy "Safari discoveries are public"
+  on public.safari_discoveries for select using (true);
+
+drop policy if exists "Anyone can log a Safari discovery" on public.safari_discoveries;
+create policy "Anyone can log a Safari discovery"
+  on public.safari_discoveries for insert with check (true);
+
+-- No update / delete policies → those operations are denied for anon by default.
+
+-- 7) Seed the catalog --------------------------------------------------------
+-- Keep in sync with ANIMALS in
+--   src/app/pages/animal-safari-match/safari-data.ts
+-- The block below is re-run safe: it makes the schema current, removes any stale
+-- animals from a previous catalog, upserts the 24-animal set, then (re)applies
+-- the theme guard once every row conforms.
+alter table public.safari_animals add column if not exists model text;
+alter table public.safari_animals drop constraint if exists safari_animals_theme_ck;
+
+delete from public.safari_animals
+  where id not in (
+    'lion','tiger','elephant','giraffe','fox','monkey','deer','hog',
+    'panda','koala','bunny','cow','pig','dog','cat','chick',
+    'polar','penguin','beaver','parrot','fish','crab','bee','caterpillar'
+  );
+
+insert into public.safari_animals (id, name, rarity, theme, emoji, model) values
+  -- Savanna
+  ('lion',        'Lion',        'legendary', 'savanna',   '🦁',     'animal-lion'),
+  ('tiger',       'Tiger',       'epic',      'savanna',   '🐯',     'animal-tiger'),
+  ('elephant',    'Elephant',    'rare',      'savanna',   '🐘',     'animal-elephant'),
+  ('giraffe',     'Giraffe',     'rare',      'savanna',   '🦒',     'animal-giraffe'),
+  ('fox',         'Fox',         'rare',      'savanna',   '🦊',     'animal-fox'),
+  ('monkey',      'Monkey',      'common',    'savanna',   '🐵',     'animal-monkey'),
+  ('deer',        'Deer',        'common',    'savanna',   '🦌',     'animal-deer'),
+  ('hog',         'Hog',         'common',    'savanna',   '🐗',     'animal-hog'),
+  -- Farmyard
+  ('panda',       'Panda',       'legendary', 'farmyard',  '🐼',     'animal-panda'),
+  ('koala',       'Koala',       'epic',      'farmyard',  '🐨',     'animal-koala'),
+  ('bunny',       'Bunny',       'rare',      'farmyard',  '🐰',     'animal-bunny'),
+  ('cow',         'Cow',         'common',    'farmyard',  '🐮',     'animal-cow'),
+  ('pig',         'Pig',         'common',    'farmyard',  '🐷',     'animal-pig'),
+  ('dog',         'Dog',         'common',    'farmyard',  '🐶',     'animal-dog'),
+  ('cat',         'Cat',         'common',    'farmyard',  '🐱',     'animal-cat'),
+  ('chick',       'Chick',       'common',    'farmyard',  '🐥',     'animal-chick'),
+  -- Riverside
+  ('polar',       'Polar Bear',  'epic',      'riverside', '🐻‍❄️', 'animal-polar'),
+  ('penguin',     'Penguin',     'rare',      'riverside', '🐧',     'animal-penguin'),
+  ('beaver',      'Beaver',      'rare',      'riverside', '🦫',     'animal-beaver'),
+  ('parrot',      'Parrot',      'rare',      'riverside', '🦜',     'animal-parrot'),
+  ('fish',        'Fish',        'common',    'riverside', '🐟',     'animal-fish'),
+  ('crab',        'Crab',        'common',    'riverside', '🦀',     'animal-crab'),
+  ('bee',         'Bee',         'common',    'riverside', '🐝',     'animal-bee'),
+  ('caterpillar', 'Caterpillar', 'common',    'riverside', '🐛',     'animal-caterpillar')
+on conflict (id) do update
+  set name   = excluded.name,
+      rarity = excluded.rarity,
+      theme  = excluded.theme,
+      emoji  = excluded.emoji,
+      model  = excluded.model;
+
+alter table public.safari_animals
+  add constraint safari_animals_theme_ck check (theme in ('savanna','farmyard','riverside'));
+
+-- ============================================================================
+-- Rollback (run only if you need to remove everything):
+--   drop view  if exists public.safari_community_totals;
+--   drop table if exists public.safari_discoveries cascade;
+--   drop table if exists public.safari_sessions    cascade;
+--   drop table if exists public.safari_animals      cascade;
+-- ============================================================================


### PR DESCRIPTION
…ions)

The Animal Safari Match component, 24 GLB models and assets were already merged in 646fbe3, but the wiring that surfaces the game was missing — so it never appeared in the arcade and the Supabase calls had no backing methods.

This completes it:
- add the /animal-safari-match route
- add the game-list entry (with cover image), replacing the Memory Match coming-soon placeholder
- add the Supabase Safari methods (anonymous play sessions + community discovery counter)
- add the animal_safari_match and perfect_harvest SQL migrations
- raise the anyComponentStyle budget to 20kB for the game's stylesheet